### PR TITLE
fix transition for animation Loader

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,8 +27,8 @@ const DiaryPage = lazy(() =>
 const App = () => {
   const dispatch = useDispatch();
   useEffect(() => {
-  dispatch(authOperations.getCurrentUser())
-}, [dispatch])
+    dispatch(authOperations.getCurrentUser())
+  }, [dispatch])
   return (
     <>
       <Header />
@@ -39,32 +39,32 @@ const App = () => {
               <HomePage />
             </Route>
 
-              <PublicRoute
-                path={paths.register}
-                restricted
-                redirectTo={paths.diary}
-              >
-                <RegisterPage />
-              </PublicRoute>
+            <PublicRoute
+              path={paths.register}
+              restricted
+              redirectTo={paths.diary}
+            >
+              <RegisterPage />
+            </PublicRoute>
 
-              <PublicRoute
-                path={paths.login}
-                restricted
-                redirectTo={paths.diary}
-              >
-                <LoginPage />
-              </PublicRoute>
+            <PublicRoute
+              path={paths.login}
+              restricted
+              redirectTo={paths.diary}
+            >
+              <LoginPage />
+            </PublicRoute>
 
-              <PrivateRoute
-                path={paths.calculator}
-                redirectTo={paths.login}
-              >
-                <CalculatorPage />
-              </PrivateRoute>
+            <PrivateRoute
+              path={paths.calculator}
+              redirectTo={paths.login}
+            >
+              <CalculatorPage />
+            </PrivateRoute>
 
-              <PrivateRoute path={paths.diary} redirectTo={paths.login}>
-                <DiaryPage />
-              </PrivateRoute>
+            <PrivateRoute path={paths.diary} redirectTo={paths.login}>
+              <DiaryPage />
+            </PrivateRoute>
 
 
             <Redirect to="/" />

--- a/src/components/common/Loader/Loader.module.scss
+++ b/src/components/common/Loader/Loader.module.scss
@@ -8,9 +8,10 @@
   position: fixed;
   left: 0;
   top: 0;
+  z-index: 999;
   background-image: linear-gradient(45deg, #eaee09de, #3bff0a8c, #ff000078);
   animation-name: flashing;
-  animation-duration: 3000ms;
+  animation-duration: 5000ms;
   animation-timing-function: linear;
   animation-iteration-count: infinite;
 }
@@ -42,13 +43,19 @@
 
 @keyframes flashing {
   0% {
+    opacity: 0.4;
+  }
+  25% {
     opacity: 1;
   }
   50% {
     opacity: 0.6;
   }
-  100% {
+  75% {
     opacity: 1;
+  }
+  100% {
+    opacity: 0.4;
   }
 }
 

--- a/src/pages/DiaryPage/DiaryPage.js
+++ b/src/pages/DiaryPage/DiaryPage.js
@@ -17,8 +17,8 @@ import DiaryProductsList from '../../components/DiaryCalendar/DiaryProductsList'
 import Button from '../../components/Button';
 
 const DiaryPage = () => {
-  const isWide = useMedia('(min-width: 768px)');
-  
+  // const isWide = useMedia('(min-width: 768px)');
+
   return (
     <div className={styles.page}>
       <DiaryDateСalendar />


### PR DESCRIPTION
Пофиксил анимацию, сделав её более плавной от нулевой прозрачной точки.
Полностью с "opacity: 0" не могу начать анимацию, т.к. если будет сценарий, что анимания пойдёт по второму циклу - у нас будет польностью прозрачный фон, а это может намекнуть юзеру что загрузка завершена.
Поэтому сделал старт анимации более прозрачным (но не полностью 😉 )